### PR TITLE
Test 22a, update CircleCI images, rename default branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build-latest:
     machine:
-      - image: ubuntu-2004:current
+      image: ubuntu-2004:current  
     steps:
         - checkout
         - matlab/install:
@@ -17,7 +17,7 @@ jobs:
 
   build-21b:
     machine:
-      - image: ubuntu-2004:current
+      image: ubuntu-2004:current
     steps:
         - checkout
         - matlab/install:
@@ -29,7 +29,7 @@ jobs:
 
   build-21a:
     machine:
-      - image: ubuntu-2004:current
+      image: ubuntu-2004:current
     steps:
         - checkout
         - matlab/install:
@@ -41,7 +41,7 @@ jobs:
 
   build-20b:
     machine:
-      - image: ubuntu-2004:current
+      image: ubuntu-2004:current
     steps:
         - checkout
         - matlab/install:
@@ -53,7 +53,7 @@ jobs:
   
   build-20a:
     machine:
-      - image: ubuntu-2004:current
+      image: ubuntu-2004:current
     steps:
         - checkout
         - matlab/install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ orbs:
   
 jobs:
   build-latest:
-    docker:
-      - image: cimg/base:stable
+    machine:
+      - image: ubuntu-2004:current
     steps:
         - checkout
         - matlab/install:
@@ -16,8 +16,8 @@ jobs:
             path: test-results
 
   build-21b:
-    docker:
-      - image: cimg/base:stable
+    machine:
+      - image: ubuntu-2004:current
     steps:
         - checkout
         - matlab/install:
@@ -28,8 +28,8 @@ jobs:
             path: test-results
 
   build-21a:
-    docker:
-      - image: cimg/base:stable
+    machine:
+      - image: ubuntu-2004:current
     steps:
         - checkout
         - matlab/install:
@@ -40,8 +40,8 @@ jobs:
             path: test-results             
 
   build-20b:
-    docker:
-      - image: cimg/base:stable
+    machine:
+      - image: ubuntu-2004:current
     steps:
         - checkout
         - matlab/install:
@@ -52,8 +52,8 @@ jobs:
             path: test-results             
   
   build-20a:
-    docker:
-      - image: cimg/base:stable
+    machine:
+      - image: ubuntu-2004:current
     steps:
         - checkout
         - matlab/install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ orbs:
   
 jobs:
   build-latest:
-    machine:
-      image: ubuntu-1604:201903-01
+    docker:
+      image: cimg/base:stable
     steps:
         - checkout
         - matlab/install:
@@ -15,9 +15,21 @@ jobs:
         - store_test_results:
             path: test-results
 
+  build-21b:
+    docker:
+      image: cimg/base:stable
+    steps:
+        - checkout
+        - matlab/install:
+            release: R2021b
+        - matlab/run-tests:
+            test-results-junit: test-results/matlab/results.xml
+        - store_test_results:
+            path: test-results
+
   build-21a:
-    machine:
-      image: ubuntu-1604:201903-01
+    docker:
+      image: cimg/base:stable
     steps:
         - checkout
         - matlab/install:
@@ -28,8 +40,8 @@ jobs:
             path: test-results             
 
   build-20b:
-    machine:
-      image: ubuntu-1604:201903-01
+    docker:
+      image: cimg/base:stable
     steps:
         - checkout
         - matlab/install:
@@ -40,8 +52,8 @@ jobs:
             path: test-results             
   
   build-20a:
-    machine:
-      image: ubuntu-1604:201903-01
+    docker:
+      image: cimg/base:stable
     steps:
         - checkout
         - matlab/install:
@@ -56,6 +68,7 @@ workflows:
   multiple-matlabs:
     jobs:
       - build-latest
+      - build-21b
       - build-21a
       - build-20b
       - build-20a       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build-latest:
     docker:
-      image: cimg/base:stable
+      - image: cimg/base:stable
     steps:
         - checkout
         - matlab/install:
@@ -17,7 +17,7 @@ jobs:
 
   build-21b:
     docker:
-      image: cimg/base:stable
+      - image: cimg/base:stable
     steps:
         - checkout
         - matlab/install:
@@ -29,7 +29,7 @@ jobs:
 
   build-21a:
     docker:
-      image: cimg/base:stable
+      - image: cimg/base:stable
     steps:
         - checkout
         - matlab/install:
@@ -41,7 +41,7 @@ jobs:
 
   build-20b:
     docker:
-      image: cimg/base:stable
+      - image: cimg/base:stable
     steps:
         - checkout
         - matlab/install:
@@ -53,7 +53,7 @@ jobs:
   
   build-20a:
     docker:
-      image: cimg/base:stable
+      - image: cimg/base:stable
     steps:
         - checkout
         - matlab/install:


### PR DESCRIPTION
1. Changed CircleCI configuration to test on 22a
2. Updated CircleCI machine images to [ubuntu-2004:current](https://circleci.com/blog/ubuntu-14-16-image-deprecation/?mkt_tok=NDg1LVpNSC02MjYAAAGCndalSiRYc-V04q_ubfR0-_wDqZU6WkVu8pN69y68iWd98w7patEh8eOhsr82uuxk14NroziXnOg5gef_kT5BgdFsXOpLSakqxN2P1IbktQFy)
3. Renamed default branch to ```main```